### PR TITLE
Update 'Building the kernel' documentation 

### DIFF
--- a/ref/README.md
+++ b/ref/README.md
@@ -1,8 +1,8 @@
 This is the reference implementation of the `c_sw` kernel extracted from the FV3 model.
 It is an excellent kernel for OpenMP analysis. The number of threads is determined by
-the OMP_NUM_THREADS environment variable, which defaults to the number of hyperthreads
+the `OMP_NUM_THREADS` environment variable, which defaults to the number of hyperthreads
 on the machine if it is not set.  Currently the number of threads is hard-coded to 4 in
-the build script when running "ctest", but users can customize it at runtime for other
+the build script when running `ctest`, but users can customize it at runtime for other
 runs.
 
 # Building the kernel
@@ -29,20 +29,19 @@ make VERBOSE=1
 
 ### Machines that use modules to manage software
 
-You may need to load modules for your compiler, NetCDF, and/or cmake before following the steps above.
+You may need to load modules for your compiler, NetCDF, and/or cmake before following the steps above. For example:  
 
-For example, "module load intel netcdf cmake".
+ `module load intel netcdf cmake`
 
 ### Machines that do not use modules to manage software
 
-If NetCDF is not installed in a standard location where cmake can find it, you may need to add the paths where your NetCDF and NetCDF-Fortran are installed to the CMAKE_PREFIX_PATH variable. For example:
+If NetCDF is not installed in a standard location where cmake can find it, you may need to add the paths where your NetCDF and NetCDF-Fortran are installed to the `CMAKE_PREFIX_PATH variable`. For example:
 
-export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:/path/to/netcdf:/path/to/netcdf-fortran
+`export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:/path/to/netcdf:/path/to/netcdf-fortran`
 
 ### Building on a Mac
 
-By default, gcc points to the clang compiler on Mac. The clang compiler is not yet supported. To use the GNU compiler on Mac, depending on how the GNU compiler was installed, you may need to specify the c compiler name as gcc-$version. For example: gcc-10
-
+By default, gcc points to the clang compiler on Mac. The clang compiler is not yet supported. To use the GNU compiler on Mac, depending on how the GNU compiler was installed, you may need to specify the c compiler name as gcc-$version. For example: `gcc-10`
 ## Testing the kernel
 
 To run the test suite (from the build directory):

--- a/ref/README.md
+++ b/ref/README.md
@@ -5,7 +5,7 @@ on the machine if it is not set.  Currently the number of threads is hard-coded 
 the build script when running "ctest", but users can customize it at runtime for other
 runs.
 
-## Building the kernel
+## Building the kernel (HPC systems with modules)
 
 This kernel uses an out-of-source cmake build, meaning that the build must be done in 
 directory that is not in the source tree.
@@ -21,7 +21,26 @@ cmake -DCMAKE_BUILD_TYPE=<debug | release> ..
 make VERBOSE=1
 ```
 
+### Building the kernel (Systems without modules)
+
+```
+rm -rf build ; mkdir build ; cd build
+export CC=<gcc | icc>
+export FC=<gfortran | ifort> 
+cmake -DCMAKE_BUILD_TYPE=<debug | release> ..
+make VERBOSE=1
+```
+
+### Additional description for build configurations 
+
+Some alterations could potentially need to be made in regards to the CC and FC compilers  
+* export CC= < appropriate compiler version being used (ie. gcc-10) > 
+* export FC= < appropriate compiler being used >
+
+
 ## Testing the kernel
+
+Ensure system is quipped with LFS to run the .nl files in test/test_input 
 
 To run the test suite (from the build directory):
 

--- a/ref/README.md
+++ b/ref/README.md
@@ -34,8 +34,13 @@ make VERBOSE=1
 ### Additional description for build configurations 
 
 Some alterations could potentially need to be made in regards to the CC and FC compilers  
-* export CC= < appropriate compiler version being used (ie. gcc-10) > 
-* export FC= < appropriate compiler being used >
+
+Confirm and identifiy which compiler will be used on the system.  
+
+* export CC= < appropriate compiler & version  > 
+* export FC= < appropriate compiler & version  >
+
+For Example : ```export CC=gcc-10```
 
 
 ## Testing the kernel

--- a/ref/README.md
+++ b/ref/README.md
@@ -17,25 +17,7 @@ directory that is not in the source tree.
 * cmake 
 * git-lfs 
 
-## Machines that use modules to manage software
-
-The build procedure is (from the directory containing this file):
-
-```
-rm -rf build ; mkdir build ; cd build
-module load <compiler> netcdf cmake
-export CC=<gcc | icc>
-export FC=<gfortran | ifort>
-cmake -DCMAKE_BUILD_TYPE=<debug | release> ..
-make VERBOSE=1
-```
-You may need to load modules for your compiler, NetCDF, and/or cmake before following the steps above.
-
-For example, "module load intel netcdf cmake".
-
-## Machines that do not use modules to manage software
-
-The build procedure is (from the directory containing this file):
+## Basic build procedure (from the directory containing this file)
 
 ```
 rm -rf build ; mkdir build ; cd build
@@ -44,10 +26,18 @@ export FC=<name of fortran compiler>
 cmake -DCMAKE_BUILD_TYPE=<debug | release> ..
 make VERBOSE=1
 ```
+
+### Machines that use modules to manage software
+
+You may need to load modules for your compiler, NetCDF, and/or cmake before following the steps above.
+
+For example, "module load intel netcdf cmake".
+
+### Machines that do not use modules to manage software
+
 If NetCDF is not installed in a standard location where cmake can find it, you may need to add the paths where your NetCDF and NetCDF-Fortran are installed to the CMAKE_PREFIX_PATH variable. For example:
 
 export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:/path/to/netcdf:/path/to/netcdf-fortran
-
 
 ### Building on a Mac
 

--- a/ref/README.md
+++ b/ref/README.md
@@ -5,10 +5,19 @@ on the machine if it is not set.  Currently the number of threads is hard-coded 
 the build script when running "ctest", but users can customize it at runtime for other
 runs.
 
-## Building the kernel (HPC systems with modules)
+# Building the kernel
 
 This kernel uses an out-of-source cmake build, meaning that the build must be done in 
 directory that is not in the source tree.
+
+## Dependencies 
+* C Compiler
+* Fortran Compiler
+* NetCDF 
+* cmake 
+* git-lfs 
+
+## Machines that use modules to manage software
 
 The build procedure is (from the directory containing this file):
 
@@ -20,32 +29,31 @@ export FC=<gfortran | ifort>
 cmake -DCMAKE_BUILD_TYPE=<debug | release> ..
 make VERBOSE=1
 ```
+You may need to load modules for your compiler, NetCDF, and/or cmake before following the steps above.
 
-### Building the kernel (Systems without modules)
+For example, "module load intel netcdf cmake".
+
+## Machines that do not use modules to manage software
+
+The build procedure is (from the directory containing this file):
 
 ```
 rm -rf build ; mkdir build ; cd build
-export CC=<gcc | icc>
-export FC=<gfortran | ifort> 
+export CC=<name of C compiler>
+export FC=<name of fortran compiler> 
 cmake -DCMAKE_BUILD_TYPE=<debug | release> ..
 make VERBOSE=1
 ```
+If NetCDF is not installed in a standard location where cmake can find it, you may need to add the paths where your NetCDF and NetCDF-Fortran are installed to the CMAKE_PREFIX_PATH variable. For example:
 
-### Additional description for build configurations 
+export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:/path/to/netcdf:/path/to/netcdf-fortran
 
-Some alterations could potentially need to be made in regards to the CC and FC compilers  
 
-Confirm and identifiy which compiler will be used on the system.  
+### Building on a Mac
 
-* export CC= < appropriate compiler & version  > 
-* export FC= < appropriate compiler & version  >
-
-For Example : ```export CC=gcc-10```
-
+By default, gcc points to the clang compiler on Mac. The clang compiler is not yet supported. To use the GNU compiler on Mac, depending on how the GNU compiler was installed, you may need to specify the c compiler name as gcc-$version. For example: gcc-10
 
 ## Testing the kernel
-
-Ensure system is quipped with LFS to run the .nl files in test/test_input 
 
 To run the test suite (from the build directory):
 


### PR DESCRIPTION
When building and testing the kernel on Mac OS, some complications were encountered. Updates to the ref/README.md file include descriptions in resolving some of the issues found.   

Not included were any specifics about altering the src/sw_driver.f90 file to comment out  ```ret = print_affinity(0)``` , and commenting out the C code in the src/CMakeLIsts.txt file. 

In adding "Additional Description for build configurations" I am unsure as to how much detail to go into (if appropriate).

@christopherwharrop-noaa & @LyndStringer, I am not able to add you two as reviewers for this PR. 