### PR TITLE
Add OpenMP settings to build.sh script.

### DIFF
--- a/ref/build.sh
+++ b/ref/build.sh
@@ -58,5 +58,7 @@ cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
 make -j4 VERBOSE=1
 
 # Run the test suite
+export OMP_PLACES=cores
+export OMP_PROC_BIND=close
 export OMP_NUM_THREADS=4
 ctest


### PR DESCRIPTION
Add setting of
```bash
export OMP_PLACES=cores
export OMP_PROC_BIND=close
```
to the build.sh build script.  They were added to the README.md in #8.  Closes #1. 
