### PR TITLE
Add a 'apt-get update' build step for Ubuntu CI status check.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,10 @@ jobs:
         with:
           lfs: true
 
+      # Update
+      - name: Update
+        run: sudo apt-get update
+
       # Install NetCDF
       - name: Install NetCDF
         run: sudo apt-get install libnetcdf-dev -y


### PR DESCRIPTION
Installation of NetCDF and other packages may fail without it.